### PR TITLE
Add support for internal load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,8 @@ module "alb" {
   source  = "terraform-aws-modules/alb/aws"
   version = "v4.0.0"
 
-  load_balancer_name = var.name
+  load_balancer_name        = var.name
+  load_balancer_is_internal = var.internal
 
   vpc_id          = local.vpc_id
   subnets         = local.public_subnet_ids
@@ -528,4 +529,3 @@ resource "aws_cloudwatch_log_group" "atlantis" {
 
   tags = local.tags
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "name" {
   default     = "atlantis"
 }
 
+variable "internal" {
+  description = "Whether the load balancer is internal or external"
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "A map of tags to use on all resources"
   type        = map(string)


### PR DESCRIPTION
Fixes https://github.com/terraform-aws-modules/terraform-aws-atlantis/issues/69

Add a bool variable `internal` that defaults to false and is used in the `alb` module.
The name matches the rename in terraform-aws-alb 5.0,
https://github.com/terraform-aws-modules/terraform-aws-alb/blob/master/UPGRADE-5.0.md
and is consistent with the `name` variable.